### PR TITLE
Add an Express server implementation for MBSTF tutorial

### DIFF
--- a/express-mock-media-server/.gitignore
+++ b/express-mock-media-server/.gitignore
@@ -1,0 +1,2 @@
+package-lock.json
+node_modules/

--- a/express-mock-media-server/Readme.md
+++ b/express-mock-media-server/Readme.md
@@ -1,0 +1,32 @@
+# Express Mock Media Server
+
+## Introduction
+
+This project provides a very simple HTTP server that implements a simple set of object downloads with varying redirections.
+
+This server is intended to be used for development when static responses are enough to implement or test a new feature.
+
+## Downloading
+
+The source can be obtained by cloning the github repository.
+
+```
+cd ~
+git clone https://github.com/5G-MAG/rt-mbs-examples.git
+```
+
+## Building
+
+````
+cd ~/rt-mbs-examples/express-mock-media-server
+npm install
+```` 
+
+## Running
+
+````
+cd ~/rt-mbs-examples/express-mock-media-server
+npm start
+```` 
+
+The server is started on port `3004` per default, this can be changed by setting the PORT environment variable.

--- a/express-mock-media-server/app.js
+++ b/express-mock-media-server/app.js
@@ -1,0 +1,25 @@
+var express = require('express');
+var path = require('path');
+var cookieParser = require('cookie-parser');
+var logger = require('morgan');
+var cors = require('cors');
+const bodyParser = require('body-parser');
+require('body-parser-xml')(bodyParser);
+
+var indexRouter = require('./routes/index');
+
+var app = express();
+
+app.use(logger('dev'));
+app.use(express.json());
+
+app.use(express.urlencoded({ extended: false }));
+app.use(cookieParser());
+app.use(cors());
+//app.use(bodyParser.xml());
+app.use(bodyParser.text({ type: 'application/xml' }));
+app.use(express.static(path.join(__dirname, 'public')));
+
+app.use('/', indexRouter);
+
+module.exports = app;

--- a/express-mock-media-server/app.js
+++ b/express-mock-media-server/app.js
@@ -18,7 +18,7 @@ app.use(cookieParser());
 app.use(cors());
 //app.use(bodyParser.xml());
 app.use(bodyParser.text({ type: 'application/xml' }));
-app.use(express.static(path.join(__dirname, 'public')));
+app.use(express.static(path.join(__dirname, 'public'), {etag: true, index: false, lastModified: true, setHeaders(res, path, stat) { res.set('Content-Type', 'text/plain'); } }));
 
 app.use('/', indexRouter);
 

--- a/express-mock-media-server/bin/www
+++ b/express-mock-media-server/bin/www
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+
+/**
+ * Module dependencies.
+ */
+
+var app = require('../app');
+var debug = require('debug')('express-mock-media-server:server');
+var http = require('http');
+
+/**
+ * Get port from environment and store in Express.
+ */
+
+var port = normalizePort(process.env.PORT || '3004');
+app.set('port', port);
+
+/**
+ * Create HTTP server.
+ */
+
+var server = http.createServer(app);
+
+/**
+ * Listen on provided port, on all network interfaces.
+ */
+
+server.listen(port);
+server.on('error', onError);
+server.on('listening', onListening);
+
+/**
+ * Normalize a port into a number, string, or false.
+ */
+
+function normalizePort(val) {
+  var port = parseInt(val, 10);
+
+  if (isNaN(port)) {
+    // named pipe
+    return val;
+  }
+
+  if (port >= 0) {
+    // port number
+    return port;
+  }
+
+  return false;
+}
+
+/**
+ * Event listener for HTTP server "error" event.
+ */
+
+function onError(error) {
+  if (error.syscall !== 'listen') {
+    throw error;
+  }
+
+  var bind = typeof port === 'string'
+    ? 'Pipe ' + port
+    : 'Port ' + port;
+
+  // handle specific listen errors with friendly messages
+  switch (error.code) {
+    case 'EACCES':
+      console.error(bind + ' requires elevated privileges');
+      process.exit(1);
+      break;
+    case 'EADDRINUSE':
+      console.error(bind + ' is already in use');
+      process.exit(1);
+      break;
+    default:
+      throw error;
+  }
+}
+
+/**
+ * Event listener for HTTP server "listening" event.
+ */
+
+function onListening() {
+  var addr = server.address();
+  var bind = typeof addr === 'string'
+    ? 'pipe ' + addr
+    : 'port ' + addr.port;
+  debug('Listening on ' + bind);
+}

--- a/express-mock-media-server/package.json
+++ b/express-mock-media-server/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "express-mock-media-server",
+  "version": "1.1.0",
+  "private": true,
+  "scripts": {
+    "start": "node ./bin/www"
+  },
+  "dependencies": {
+    "body-parser": "^1.20.2",
+    "body-parser-xml": "^2.0.5",
+    "cookie-parser": "~1.4.4",
+    "cors": "^2.8.5",
+    "debug": "~2.6.9",
+    "express": "^4.21.2",
+    "morgan": "~1.9.1"
+  },
+  "devDependencies": {
+    "moment": "^2.30.1"
+  }
+}

--- a/express-mock-media-server/public/object1
+++ b/express-mock-media-server/public/object1
@@ -1,0 +1,1 @@
+This is a direct download for object1.

--- a/express-mock-media-server/public/real-object2
+++ b/express-mock-media-server/public/real-object2
@@ -1,0 +1,1 @@
+This is the real download for temporary redirect from object2. (object2 (T)=> real-object2)

--- a/express-mock-media-server/public/real-object3
+++ b/express-mock-media-server/public/real-object3
@@ -1,0 +1,1 @@
+This is the real download for a permanent then temporary redirect from object3. (object3 (P)=> perm-object3 (T)=> real-object3)

--- a/express-mock-media-server/public/real-object4
+++ b/express-mock-media-server/public/real-object4
@@ -1,0 +1,1 @@
+This is the real download for a temporary then permanent redirect from object4. (object4 (T)=> temp-object4 (P)=> real-object4)

--- a/express-mock-media-server/routes/index.js
+++ b/express-mock-media-server/routes/index.js
@@ -1,0 +1,29 @@
+var express = require('express');
+var router = express.Router();
+
+/* GET /object2 - temporary redirect to /real-object2 */
+router.get('/object2', function(req, res, next) {
+  res.redirect(302, '/real-object2');
+});
+
+/* GET /object3 - permanent redirect to /perm-object3 */
+router.get('/object3', function(req, res, next) {
+  res.redirect(301, '/perm-object3');
+});
+
+/* GET /perm-object3 - temporary redirect to /real-object3 */
+router.get('/perm-object3', function(req, res, next) {
+  res.redirect(302, '/real-object3');
+});
+
+/* GET /object4 - temporary redirect to /temp-object4 */
+router.get('/object4', function(req, res, next) {
+  res.redirect(302, '/temp-object4');
+});
+
+/* GET /temp-object4 - permanent redirect to /real-object4 */
+router.get('/temp-object4', function(req, res, next) {
+  res.redirect(301, '/real-object4');
+});
+
+module.exports = router;

--- a/express-mock-media-server/utils/Utils.js
+++ b/express-mock-media-server/utils/Utils.js
@@ -1,0 +1,20 @@
+const fs = require('fs');
+const path = require('path')
+
+class Utils {
+
+    static writeToDisk(filepath, content) {
+        return new Promise((resolve, reject) => {
+            fs.mkdirSync(path.dirname(filepath), { recursive: true });
+            fs.writeFile(filepath, content, (err) => {
+                if (err) {
+                    reject(err)
+                } else {
+                    resolve()
+                }
+            })
+        })
+    }
+}
+
+module.exports = Utils


### PR DESCRIPTION
This adds an implementation of a NodeJS [Express](https://expressjs.com/) server that will serve media files as requested by the example configurations in the MBSTF Tutorial added in PR 5G-MAG/Getting-Started#223.
