### PR TITLE
Startup script for MBSF Tutorial

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ env.bak/
 venv.bak/
 
 bake-remote.hcl
+
+.idea

--- a/scripts/tmux/Readme.md
+++ b/scripts/tmux/Readme.md
@@ -1,6 +1,6 @@
 # Description
 
-This folder contains scripts for the tmux](https://github.com/tmux/tmux)  is a terminal multiplexer.
+This folder contains scripts for the [tmux](https://github.com/tmux/tmux)  is a terminal multiplexer.
 
 ## Usage
 
@@ -15,8 +15,7 @@ bash ./<script-name>.sh
 ### Stopping
 
 In general, to stop the tmux session started by the scripts, attach to the tmux session and stop processes. In the tmux
-session, press `Ctrl+b` followed by `d` to detach from the session. Then, to kill the tmux session press `Ctrl-b` and
-then type `kill-session` and hit Enter.
+session, press `Ctrl+b` and then type `kill-session` and hit Enter.
 
 As an alternative kill the tmux session from a normal session with `tmux kill-session -t <session-name>`. For instance:
 `tmux kill-session -t mbsf-tutorial`.
@@ -29,13 +28,12 @@ In the following the different scripts available are described.
 
 The `mbs-function-tutorial-startup.sh` script starts the tmux session for
 the [MBSF Tutorial](https://hub.5g-mag.com/Getting-Started/pages/5g-multicast-broadcast-services/tutorials/mbsf.html).
-It makes it easier to start all the required processes required for execution of the tutorial. Namely, it starts the
-following components:
-This replaces the manual steps described in
+It makes it easier to start all the required processes required for execution of the tutorial. This replaces the manual
+steps described in
 the [Prerequisites](https://hub.5g-mag.com/Getting-Started/pages/5g-multicast-broadcast-services/tutorials/mbsf.html#prerequisites)
-step of the tutorial.
+step of the tutorial. Namely, it starts the following components:
 
-* The NRF, SCP, MB-SMF, MB-UPF, MB-AMF and UDM Network Functions of
+* The `NRF`, `SCP`, `MB-SMF`, `MB-UPF`, `MB-AMF` and `UDM` Network Functions of
   the [Open5GS core](https://github.com/5G-MAG/open5gs)
 * The [MBSTF](https://github.com/5G-MAG/rt-mbs-transport-function)
 * The [MBSF](https://github.com/5G-MAG/rt-mbs-function)
@@ -48,9 +46,15 @@ step of the tutorial.
 2. Copy your `local-mbsf.yaml` MBSF configuration file to the path defined in `BASE_DIR`.
 3. Run `bash ./mbs-function-tutorial-startup.sh` to start the tmux session with all the required components.
 4. You can navigate between the different panes using `Ctrl+b` followed by the arrow keys or by typing the concrete
-   number of the pane you want to switch to. Navigate to the `UPF`, `MBSTF` and `MBSF` panes and enter the `sudo` password.
-5. Now all processes should be running. You can continue using the components now. 
+   number of the pane you want to switch to. Navigate to the `UPF` (`Ctrl+b 3`) pane and enter the `sudo`
+   password.
+5. Now all processes should be running. You can continue using the components now.
 
 ##### Stopping the MBSF Tutorial tmux session
 
-In a normal shell run `tmux kill-session -t mbsf-tutorial`.
+In the tmux session, press `Ctrl+b` followed by `:kill-session` and hit Enter.
+
+As an alternative, in a normal shell run `tmux kill-session -t mbsf-tutorial`.
+
+In case there are still Open5GS processes running you can terminate them with
+`sudo pkill -TERM -f 'open5gs-(nrfd|scpd|smfd|upfd|amfd|udmd|mbstfd|mbsfd)'`

--- a/scripts/tmux/Readme.md
+++ b/scripts/tmux/Readme.md
@@ -1,6 +1,7 @@
 # Description
 
-This folder contains scripts for the [tmux](https://github.com/tmux/tmux)  is a terminal multiplexer.
+This folder contains scripts for [tmux](https://github.com/tmux/tmux) an open-source terminal multiplexer that allows
+users to manage multiple terminal sessions, windows, and panes from a single screen or terminal window.
 
 ## Usage
 

--- a/scripts/tmux/Readme.md
+++ b/scripts/tmux/Readme.md
@@ -42,13 +42,13 @@ step of the tutorial. Namely, it starts the following components:
 
 ##### Starting the MBSF Tutorial tmux session
 
-1. Open `mbs-function-tutorial-startup.sh` and set the URL to your Open5GS folder in the `BASE_DIR` variable.
-2. Copy your `local-mbsf.yaml` MBSF configuration file to the path defined in `BASE_DIR`.
-3. Run `bash ./mbs-function-tutorial-startup.sh` to start the tmux session with all the required components.
-4. You can navigate between the different panes using `Ctrl+b` followed by the arrow keys or by typing the concrete
+1. From the root folder of this project navigate to `scripts/tmux` 
+1. Optional: Adjust the MBSF configuration located in `local-mbsf.yaml` if needed.
+1. Run `bash ./mbs-function-tutorial-startup.sh` to start the tmux session with all the required components.
+1. You can navigate between the different panes using `Ctrl+b` followed by the arrow keys or by typing the concrete
    number of the pane you want to switch to. Navigate to the `UPF` (`Ctrl+b 3`) pane and enter the `sudo`
    password.
-5. Now all processes should be running. You can continue using the components now.
+1. Now all processes should be running. You can continue using the components now.
 
 ##### Stopping the MBSF Tutorial tmux session
 

--- a/scripts/tmux/Readme.md
+++ b/scripts/tmux/Readme.md
@@ -1,0 +1,56 @@
+# Description
+
+This folder contains scripts for the tmux](https://github.com/tmux/tmux)  is a terminal multiplexer.
+
+## Usage
+
+### Starting
+
+In general, to use the tmux scripts, run the following command:
+
+```bash
+bash ./<script-name>.sh
+```
+
+### Stopping
+
+In general, to stop the tmux session started by the scripts, attach to the tmux session and stop processes. In the tmux
+session, press `Ctrl+b` followed by `d` to detach from the session. Then, to kill the tmux session press `Ctrl-b` and
+then type `kill-session` and hit Enter.
+
+As an alternative kill the tmux session from a normal session with `tmux kill-session -t <session-name>`. For instance:
+`tmux kill-session -t mbsf-tutorial`.
+
+## Scripts
+
+In the following the different scripts available are described.
+
+### MBSF Tutorial Startup script
+
+The `mbs-function-tutorial-startup.sh` script starts the tmux session for
+the [MBSF Tutorial](https://hub.5g-mag.com/Getting-Started/pages/5g-multicast-broadcast-services/tutorials/mbsf.html).
+It makes it easier to start all the required processes required for execution of the tutorial. Namely, it starts the
+following components:
+This replaces the manual steps described in
+the [Prerequisites](https://hub.5g-mag.com/Getting-Started/pages/5g-multicast-broadcast-services/tutorials/mbsf.html#prerequisites)
+step of the tutorial.
+
+* The NRF, SCP, MB-SMF, MB-UPF, MB-AMF and UDM Network Functions of
+  the [Open5GS core](https://github.com/5G-MAG/open5gs)
+* The [MBSTF](https://github.com/5G-MAG/rt-mbs-transport-function)
+* The [MBSF](https://github.com/5G-MAG/rt-mbs-function)
+
+#### Usage
+
+##### Starting the MBSF Tutorial tmux session
+
+1. Open `mbs-function-tutorial-startup.sh` and set the URL to your Open5GS folder in the `BASE_DIR` variable.
+2. Copy your `local-mbsf.yaml` MBSF configuration file to the path defined in `BASE_DIR`.
+3. Run `bash ./mbs-function-tutorial-startup.sh` to start the tmux session with all the required components.
+4. You can navigate between the different panes using `Ctrl+b` followed by the arrow keys or by typing the concrete
+   number of the pane you want to switch to. Navigate to the `UPF`, `MBSTF` and `MBSF` panes and enter the `sudo` password.
+5. Now all processes should be running. You can continue using the components now. 
+
+##### Stopping the MBSF Tutorial tmux session
+
+In a normal shell run `tmux kill-session -t mbsf-tutorial`.

--- a/scripts/tmux/Readme.md
+++ b/scripts/tmux/Readme.md
@@ -44,6 +44,7 @@ step of the tutorial. Namely, it starts the following components:
 ##### Starting the MBSF Tutorial tmux session
 
 1. From the root folder of this project navigate to `scripts/tmux` 
+1. In `mbs-function-tutorial-startup.sh` adjust the `BASE_DIR` to point to your Open5GS MBS folder.
 1. Optional: Adjust the MBSF configuration located in `local-mbsf.yaml` if needed.
 1. Run `bash ./mbs-function-tutorial-startup.sh` to start the tmux session with all the required components.
 1. You can navigate between the different panes using `Ctrl+b` followed by the arrow keys or by typing the concrete

--- a/scripts/tmux/Readme.md
+++ b/scripts/tmux/Readme.md
@@ -43,7 +43,7 @@ step of the tutorial. Namely, it starts the following components:
 
 ##### Starting the MBSF Tutorial tmux session
 
-1. Open `mbs-function-tutorial-startup.sh` and set the URL to your Open5GS folder in the `BASE_DIR` variable.
+1. Open `mbs-function-tutorial-startup.sh` and set the path to your Open5GS folder in the `BASE_DIR` variable.
 2. Copy your `local-mbsf.yaml` MBSF configuration file to the path defined in `BASE_DIR`.
 3. Run `bash ./mbs-function-tutorial-startup.sh` to start the tmux session with all the required components.
 4. You can navigate between the different panes using `Ctrl+b` followed by the arrow keys or by typing the concrete

--- a/scripts/tmux/local-mbsf.yaml
+++ b/scripts/tmux/local-mbsf.yaml
@@ -1,0 +1,30 @@
+global:
+  max:
+    ue: 128
+
+logger:
+  level: debug
+
+mbsf:
+  sbi:
+    server:
+      - address: 127.0.0.68
+        port: 7777
+    client:
+      scp:
+        - uri: http://127.0.0.200:7777
+      nrf:
+        - uri: http://127.0.0.10:7777
+  mbsUserServices:
+    - addr: 127.0.0.68
+      port: 7777
+  mbsUserDataIngestSession:
+    - addr: 127.0.0.68
+      port: 7777
+  serverResponseCacheControl:
+    - maxAge: 60
+      mbsUserServiceMaxAge: 60
+      mbsUserDataIngestSessionMaxAge: 60
+  activeDistributionSessionsSoftLimit: 1000
+  activeUserServicesSoftLimit: 50
+  actPeriodGoToEstablishedState: 60

--- a/scripts/tmux/mbs-function-tutorial-startup.sh
+++ b/scripts/tmux/mbs-function-tutorial-startup.sh
@@ -2,6 +2,41 @@
 
 SESSION="mbsf-tutorial"
 BASE_DIR=~/5gmag/open5gs_mbs_development
+PANE_PGIDS=()
+
+register_pane_pgid() {
+  local pane_id="$1"
+  local pane_pid
+  local pgid
+
+  # Get the PID of the pane's process
+  pane_pid="$(tmux display-message -p -t "$pane_id" "#{pane_pid}")"
+
+  # Get the process group ID
+  pgid="$(ps -o pgid= -p "$pane_pid" | tr -d ' ')"
+
+  # Append to list of PGIDs
+  if [[ -n "$pgid" ]]; then
+    PANE_PGIDS+=("$pgid")
+  fi
+}
+
+cleanup() {
+  if tmux has-session -t "$SESSION" 2>/dev/null; then
+    return
+  fi
+
+  # Terminate all process groups tied to panes from this session.
+  for pgid in "${PANE_PGIDS[@]}"; do
+    kill -TERM -- "-$pgid" 2>/dev/null || true
+  done
+  sleep 1
+  for pgid in "${PANE_PGIDS[@]}"; do
+    kill -KILL -- "-$pgid" 2>/dev/null || true
+  done
+}
+
+trap cleanup EXIT
 
 # End existing session if it exists
 
@@ -10,27 +45,35 @@ tmux kill-session -t $SESSION 2>/dev/null
 # New session with new windows
 
 tmux new-session -d -s $SESSION -n "NRF"
+register_pane_pgid "$SESSION:NRF"
 tmux send-keys -t $SESSION:NRF "$BASE_DIR/install/bin/open5gs-nrfd" Enter
 
 tmux new-window -t $SESSION -n "SCP"
+register_pane_pgid "$SESSION:SCP"
 tmux send-keys -t $SESSION:SCP "$BASE_DIR/install/bin/open5gs-scpd" Enter
 
 tmux new-window -t $SESSION -n "SMF"
+register_pane_pgid "$SESSION:SMF"
 tmux send-keys -t $SESSION:SMF "$BASE_DIR/install/bin/open5gs-smfd" Enter
 
 tmux new-window -t $SESSION -n "UPF"
+register_pane_pgid "$SESSION:UPF"
 tmux send-keys -t $SESSION:UPF "sudo $BASE_DIR/install/bin/open5gs-upfd" Enter
 
 tmux new-window -t $SESSION -n "AMF"
+register_pane_pgid "$SESSION:AMF"
 tmux send-keys -t $SESSION:AMF "$BASE_DIR/install/bin/open5gs-amfd" Enter
 
 tmux new-window -t $SESSION -n "UDM"
+register_pane_pgid "$SESSION:UDM"
 tmux send-keys -t $SESSION:UDM "$BASE_DIR/install/bin/open5gs-udmd" Enter
 
 tmux new-window -t $SESSION -n "MBSTF"
+register_pane_pgid "$SESSION:MBSTF"
 tmux send-keys -t $SESSION:MBSTF "sudo /usr/local/bin/open5gs-mbstfd" Enter
 
 tmux new-window -t $SESSION -n "MBSF"
+register_pane_pgid "$SESSION:MBSF"
 tmux send-keys -t $SESSION:MBSF "sudo /usr/local/bin/open5gs-mbsfd -c $BASE_DIR/local-mbsf.yaml" Enter
 
 # Connect session

--- a/scripts/tmux/mbs-function-tutorial-startup.sh
+++ b/scripts/tmux/mbs-function-tutorial-startup.sh
@@ -70,11 +70,11 @@ tmux send-keys -t $SESSION:UDM "$BASE_DIR/install/bin/open5gs-udmd" Enter
 
 tmux new-window -t $SESSION -n "MBSTF"
 register_pane_pgid "$SESSION:MBSTF"
-tmux send-keys -t $SESSION:MBSTF "sudo /usr/local/bin/open5gs-mbstfd" Enter
+tmux send-keys -t $SESSION:MBSTF "/usr/local/bin/open5gs-mbstfd" Enter
 
 tmux new-window -t $SESSION -n "MBSF"
 register_pane_pgid "$SESSION:MBSF"
-tmux send-keys -t $SESSION:MBSF "sudo /usr/local/bin/open5gs-mbsfd -c $BASE_DIR/local-mbsf.yaml" Enter
+tmux send-keys -t $SESSION:MBSF "/usr/local/bin/open5gs-mbsfd -c $BASE_DIR/local-mbsf.yaml" Enter
 
 # Connect session
 

--- a/scripts/tmux/mbs-function-tutorial-startup.sh
+++ b/scripts/tmux/mbs-function-tutorial-startup.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+SESSION="mbsf-tutorial"
+BASE_DIR=~/5gmag/open5gs_mbs_development
+
+# End existing session if it exists
+
+tmux kill-session -t $SESSION 2>/dev/null
+
+# New session with new windows
+
+tmux new-session -d -s $SESSION -n "NRF"
+tmux send-keys -t $SESSION:NRF "$BASE_DIR/install/bin/open5gs-nrfd" Enter
+
+tmux new-window -t $SESSION -n "SCP"
+tmux send-keys -t $SESSION:SCP "$BASE_DIR/install/bin/open5gs-scpd" Enter
+
+tmux new-window -t $SESSION -n "SMF"
+tmux send-keys -t $SESSION:SMF "$BASE_DIR/install/bin/open5gs-smfd" Enter
+
+tmux new-window -t $SESSION -n "UPF"
+tmux send-keys -t $SESSION:UPF "sudo $BASE_DIR/install/bin/open5gs-upfd" Enter
+
+tmux new-window -t $SESSION -n "AMF"
+tmux send-keys -t $SESSION:AMF "$BASE_DIR/install/bin/open5gs-amfd" Enter
+
+tmux new-window -t $SESSION -n "UDM"
+tmux send-keys -t $SESSION:UDM "$BASE_DIR/install/bin/open5gs-udmd" Enter
+
+tmux new-window -t $SESSION -n "MBSTF"
+tmux send-keys -t $SESSION:MBSTF "sudo /usr/local/bin/open5gs-mbstfd" Enter
+
+tmux new-window -t $SESSION -n "MBSF"
+tmux send-keys -t $SESSION:MBSF "sudo /usr/local/bin/open5gs-mbsfd -c $BASE_DIR/local-mbsf.yaml" Enter
+
+# Connect session
+
+tmux attach -t $SESSION

--- a/scripts/tmux/mbs-function-tutorial-startup.sh
+++ b/scripts/tmux/mbs-function-tutorial-startup.sh
@@ -5,6 +5,7 @@ BASE_DIR=~/5gmag/open5gs_mbs_development
 PANE_PGIDS=()
 PANE_PIDS=()
 
+# PANE_PIDS stores the direct process ID of the command running in each tmux pane (the main service). PANE_PGIDS stores the process group ID for that pane, which lets you terminate any child processes spawned by the service (same process group).
 register_pane_pgid() {
   local pane_id="$1"
   local pane_pid
@@ -25,25 +26,24 @@ register_pane_pgid() {
   fi
 }
 
+kill_pane_targets() {
+  local signal="$1"
+
+  for pid in "${PANE_PIDS[@]}"; do
+    kill "$signal" "$pid" 2>/dev/null || true
+  done
+  for pgid in "${PANE_PGIDS[@]}"; do
+    kill "$signal" -- "-$pgid" 2>/dev/null || true
+  done
+}
+
 cleanup() {
   if tmux has-session -t "$SESSION" 2>/dev/null; then
     return
   fi
 
   # Terminate all process groups tied to panes from this session.
-  for pid in "${PANE_PIDS[@]}"; do
-    kill -TERM "$pid" 2>/dev/null || true
-  done
-  for pgid in "${PANE_PGIDS[@]}"; do
-    kill -TERM -- "-$pgid" 2>/dev/null || true
-  done
-  sleep 1
-  for pid in "${PANE_PIDS[@]}"; do
-    kill -KILL "$pid" 2>/dev/null || true
-  done
-  for pgid in "${PANE_PGIDS[@]}"; do
-    kill -KILL -- "-$pgid" 2>/dev/null || true
-  done
+  kill_pane_targets -TERM
 }
 
 trap cleanup EXIT

--- a/scripts/tmux/mbs-function-tutorial-startup.sh
+++ b/scripts/tmux/mbs-function-tutorial-startup.sh
@@ -75,7 +75,7 @@ register_pane_pgid "$SESSION:UDM"
 tmux new-window -t $SESSION -n "MBSTF" "/usr/local/bin/open5gs-mbstfd"
 register_pane_pgid "$SESSION:MBSTF"
 
-tmux new-window -t $SESSION -n "MBSF" "/usr/local/bin/open5gs-mbsfd -c $BASE_DIR/local-mbsf.yaml"
+tmux new-window -t $SESSION -n "MBSF" "/usr/local/bin/open5gs-mbsfd -c ./local-mbsf.yaml"
 register_pane_pgid "$SESSION:MBSF"
 
 # Connect session

--- a/scripts/tmux/mbs-function-tutorial-startup.sh
+++ b/scripts/tmux/mbs-function-tutorial-startup.sh
@@ -3,6 +3,7 @@
 SESSION="mbsf-tutorial"
 BASE_DIR=~/5gmag/open5gs_mbs_development
 PANE_PGIDS=()
+PANE_PIDS=()
 
 register_pane_pgid() {
   local pane_id="$1"
@@ -15,7 +16,10 @@ register_pane_pgid() {
   # Get the process group ID
   pgid="$(ps -o pgid= -p "$pane_pid" | tr -d ' ')"
 
-  # Append to list of PGIDs
+  if [[ -n "$pane_pid" ]]; then
+    PANE_PIDS+=("$pane_pid")
+  fi
+
   if [[ -n "$pgid" ]]; then
     PANE_PGIDS+=("$pgid")
   fi
@@ -27,10 +31,16 @@ cleanup() {
   fi
 
   # Terminate all process groups tied to panes from this session.
+  for pid in "${PANE_PIDS[@]}"; do
+    kill -TERM "$pid" 2>/dev/null || true
+  done
   for pgid in "${PANE_PGIDS[@]}"; do
     kill -TERM -- "-$pgid" 2>/dev/null || true
   done
   sleep 1
+  for pid in "${PANE_PIDS[@]}"; do
+    kill -KILL "$pid" 2>/dev/null || true
+  done
   for pgid in "${PANE_PGIDS[@]}"; do
     kill -KILL -- "-$pgid" 2>/dev/null || true
   done
@@ -44,38 +54,31 @@ tmux kill-session -t $SESSION 2>/dev/null
 
 # New session with new windows
 
-tmux new-session -d -s $SESSION -n "NRF"
+tmux new-session -d -s $SESSION -n "NRF" "$BASE_DIR/install/bin/open5gs-nrfd"
 register_pane_pgid "$SESSION:NRF"
-tmux send-keys -t $SESSION:NRF "$BASE_DIR/install/bin/open5gs-nrfd" Enter
 
-tmux new-window -t $SESSION -n "SCP"
+tmux new-window -t $SESSION -n "SCP" "$BASE_DIR/install/bin/open5gs-scpd"
 register_pane_pgid "$SESSION:SCP"
-tmux send-keys -t $SESSION:SCP "$BASE_DIR/install/bin/open5gs-scpd" Enter
 
-tmux new-window -t $SESSION -n "SMF"
+tmux new-window -t $SESSION -n "SMF" "$BASE_DIR/install/bin/open5gs-smfd"
 register_pane_pgid "$SESSION:SMF"
-tmux send-keys -t $SESSION:SMF "$BASE_DIR/install/bin/open5gs-smfd" Enter
 
-tmux new-window -t $SESSION -n "UPF"
+tmux new-window -t $SESSION -n "UPF" "sudo $BASE_DIR/install/bin/open5gs-upfd"
 register_pane_pgid "$SESSION:UPF"
-tmux send-keys -t $SESSION:UPF "sudo $BASE_DIR/install/bin/open5gs-upfd" Enter
 
-tmux new-window -t $SESSION -n "AMF"
+tmux new-window -t $SESSION -n "AMF" "$BASE_DIR/install/bin/open5gs-amfd"
 register_pane_pgid "$SESSION:AMF"
-tmux send-keys -t $SESSION:AMF "$BASE_DIR/install/bin/open5gs-amfd" Enter
 
-tmux new-window -t $SESSION -n "UDM"
+tmux new-window -t $SESSION -n "UDM" "$BASE_DIR/install/bin/open5gs-udmd"
 register_pane_pgid "$SESSION:UDM"
-tmux send-keys -t $SESSION:UDM "$BASE_DIR/install/bin/open5gs-udmd" Enter
 
-tmux new-window -t $SESSION -n "MBSTF"
+tmux new-window -t $SESSION -n "MBSTF" "/usr/local/bin/open5gs-mbstfd"
 register_pane_pgid "$SESSION:MBSTF"
-tmux send-keys -t $SESSION:MBSTF "/usr/local/bin/open5gs-mbstfd" Enter
 
-tmux new-window -t $SESSION -n "MBSF"
+tmux new-window -t $SESSION -n "MBSF" "/usr/local/bin/open5gs-mbsfd -c $BASE_DIR/local-mbsf.yaml"
 register_pane_pgid "$SESSION:MBSF"
-tmux send-keys -t $SESSION:MBSF "/usr/local/bin/open5gs-mbsfd -c $BASE_DIR/local-mbsf.yaml" Enter
 
 # Connect session
 
 tmux attach -t $SESSION
+


### PR DESCRIPTION
# Description
This PR adds a script for the starting the required components of the [MBSF tutorial](https://hub.5g-mag.com/Getting-Started/pages/5g-multicast-broadcast-services/tutorials/mbstf.html).

It makes it easier to start all the required processes required for execution of the tutorial. This replaces the manual
steps described in the [Prerequisites](https://hub.5g-mag.com/Getting-Started/pages/5g-multicast-broadcast-services/tutorials/mbsf.html#prerequisites) step of the tutorial. Namely, it starts the following components:

* The `NRF`, `SCP`, `MB-SMF`, `MB-UPF`, `MB-AMF` and `UDM` Network Functions of the [Open5GS core](https://github.com/5G-MAG/open5gs)
* The [MBSTF](https://github.com/5G-MAG/rt-mbs-transport-function)
* The [MBSF](https://github.com/5G-MAG/rt-mbs-function)

It uses the [tmux](https://github.com/tmux/tmux/wiki) terminal multiplexer.

The PR also adds a Readme file describing the usage.

Note: The basic code is AI generated with some manual refinements

<img width="3964" height="2240" alt="image" src="https://github.com/user-attachments/assets/7b9deca9-9690-4a28-aaa7-54ac81dc968f" />
